### PR TITLE
allow the "show hidden" option in jupyterlab

### DIFF
--- a/modules/sandbox/script/start-jupyter.sh
+++ b/modules/sandbox/script/start-jupyter.sh
@@ -34,4 +34,5 @@ sudo -iu $sandbox_user PATH=$PATH PROJ_LIB=/usr/share/proj NODE_PATH=$NODE_PATH:
  --NotebookApp.notebook_dir="/home/$sandbox_user"\
  --FileContentsManager.delete_to_trash=False\
  --VoilaConfiguration.enable_nbextensions=True\
- --VoilaConfiguration.show_tracebacks=True
+ --VoilaConfiguration.show_tracebacks=True\
+ --ContentsManager.allow_hidden = True


### PR DESCRIPTION
I think that now I understand how Jupyter server is started. As the server stays alive as long as the instance is running (without option for closing or restarting it) the user is unable to apply custom configuration options (as they require a restart of the server). 

I simply added here the possibility to show hidden file. when dealing with GitHub repositories that's easier if you see .giconfig, .gitignore etc....